### PR TITLE
Always apply default headers if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 7.0
   - 5.6
-  - 5.5
 
 matrix:
   allow_failures:

--- a/src/AppserverIo/Routlt/Results/RawResult.php
+++ b/src/AppserverIo/Routlt/Results/RawResult.php
@@ -58,11 +58,6 @@ class RawResult extends AbstractResult
         // add the actions default headers to the response
         if ($action instanceof DefaultHeadersAware && $action->hasDefaultHeaders()) {
             foreach ($action->getDefaultHeaders() as $name => $value) {
-                // query whether or not a header with the given name has already been set
-                if ($servletResponse->hasHeader($name)) {
-                    continue;
-                }
-
                 // if not, set the default header
                 $servletResponse->addHeader($name, $value);
             }


### PR DESCRIPTION
Values retrieved via `$action->getDefaultHeaders()` will currently not be applied if a header with the same name already exists in `$servletResponse`.